### PR TITLE
PHP 5.3 Compatibility

### DIFF
--- a/src/Utils/ConverterToHTML.php
+++ b/src/Utils/ConverterToHTML.php
@@ -15,7 +15,7 @@ class ConverterToHTML extends Converter {
 
     // Setting meta below is a hack to get our DomDocument into utf-8. All other
     // methods tried didn't work.
-    $success = $this->doc->loadXML('<xliff version="1.2" xmlns:html="http://www.w3.org/1999/xhtml" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">' . $xml . '</xliff>');
+    $success = $this->doc->loadXML('<xliff version="1.2" xmlns:xlf="urn:oasis:names:tc:xliff:document:1.2" xmlns:html="http://www.w3.org/1999/xhtml" xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">' . $xml . '</xliff>');
     $this->errorStop($error);
     $this->elementMap = array_flip($this->elementMap);
 
@@ -37,7 +37,7 @@ class ConverterToHTML extends Converter {
 
     $this->out = new \DOMDocument('1.0', 'UTF-8');
     $this->out->formatOutput = $pretty_print;
-    $field = $this->doc->getElementsByTagName('xlf:group')->item(0);
+    $field = $this->doc->getElementsByTagName('group')->item(0);
 
     foreach ($field->childNodes as $child) {
       if ($output = $this->convert($child)) {


### PR DESCRIPTION
While integrating into a project that is hosted with PHP 5.3 I was getting no contents returned when unserialising.  Appears the handling of namespaced tags has changed at some point.  By adding the namespace the element names can be the used without the "xlf:".  This is tested in 5.3 and 5.5.
- Adds xlf namespace to xliff when loading XML for conversion to HTML.
- Changes getting group elements to not include the name space (PHP 5.3 compatibility)
